### PR TITLE
Refactored: Guardian Account & Factory as extensions

### DIFF
--- a/contracts/extension/upgradeable/AccountPermissions.sol
+++ b/contracts/extension/upgradeable/AccountPermissions.sol
@@ -73,7 +73,7 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
             //isAdmin > 1, remove admin
             bool _isAdmin = _req.isAdmin == 1;
 
-            _setAdmin(targetSigner, _isAdmin, bytes(""));
+            _setAdmin(targetSigner, _isAdmin);
             return;
         }
 
@@ -200,7 +200,7 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
     }
 
     /// @notice Returns all admins of the account.
-    function getAllAdmins() external view returns (address[] memory) {
+    function getAllAdmins() public view returns (address[] memory) {
         return _accountPermissionsStorage().allAdmins.values();
     }
 
@@ -212,7 +212,7 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
     function _afterSignerPermissionsUpdate(SignerPermissionRequest calldata _req) internal virtual;
 
     /// @notice Makes the given account an admin.
-    function _setAdmin(address _account, bool _isAdmin, bytes memory _data) internal virtual {
+    function _setAdmin(address _account, bool _isAdmin) internal virtual {
         _accountPermissionsStorage().isAdmin[_account] = _isAdmin;
 
         if (_isAdmin) {

--- a/contracts/prebuilts/account/dynamic/DynamicAccount.sol
+++ b/contracts/prebuilts/account/dynamic/DynamicAccount.sol
@@ -31,15 +31,10 @@ contract DynamicAccount is AccountCore, BaseRouter {
     }
 
     /// @notice Initializes the smart contract wallet.
-    function initialize(
-        address _defaultAdmin,
-        address _commonGuardian,
-        address _accountLock,
-        bytes calldata
-    ) public override initializer {
+    function initialize(address _defaultAdmin, bytes calldata _data) public override initializer {
         __BaseRouter_init();
-        AccountCoreStorage.data().firstAdmin = _defaultAdmin;
-        _setAdmin(_defaultAdmin, true, "");
+        AccountCoreStorage.data().creationSalt = _generateSalt(_defaultAdmin, _data);
+        _setAdmin(_defaultAdmin, true);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/prebuilts/account/dynamic/DynamicAccountFactory.sol
+++ b/contracts/prebuilts/account/dynamic/DynamicAccountFactory.sol
@@ -22,15 +22,22 @@ import { DynamicAccount, IEntryPoint } from "./DynamicAccount.sol";
 //    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
 
 contract DynamicAccountFactory is BaseAccountFactory, ContractMetadata, PermissionsEnumerable {
+    address public constant ENTRYPOINT_ADDRESS = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
+
     /*///////////////////////////////////////////////////////////////
                             Constructor
     //////////////////////////////////////////////////////////////*/
 
     constructor(
-        IEntryPoint _entrypoint,
+        address _defaultAdmin,
         IExtension.Extension[] memory _defaultExtensions
-    ) BaseAccountFactory(payable(address(new DynamicAccount(_entrypoint, _defaultExtensions))), address(_entrypoint)) {
-        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    )
+        BaseAccountFactory(
+            payable(address(new DynamicAccount(IEntryPoint(ENTRYPOINT_ADDRESS), _defaultExtensions))),
+            ENTRYPOINT_ADDRESS
+        )
+    {
+        _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -38,13 +45,8 @@ contract DynamicAccountFactory is BaseAccountFactory, ContractMetadata, Permissi
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Called in `createAccount`. Initializes the account contract created in `createAccount`.
-    function _initializeAccount(
-        address _account,
-        address _admin,
-        address _commonGuardian,
-        bytes calldata _data
-    ) internal override {
-        DynamicAccount(payable(_account)).initialize(_admin, _commonGuardian, address(accountLock), _data);
+    function _initializeAccount(address _account, address _admin, bytes calldata _data) internal override {
+        DynamicAccount(payable(_account)).initialize(_admin, _data);
     }
 
     /// @dev Returns whether contract metadata can be set in the given execution context.

--- a/contracts/prebuilts/account/guardian/GuardianAccountFactory.sol
+++ b/contracts/prebuilts/account/guardian/GuardianAccountFactory.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+// Utils
+import "../utils/BaseAccountFactory.sol";
+import "../utils/BaseAccount.sol";
+import "../../../external-deps/openzeppelin/proxy/Clones.sol";
+import { Guardian } from "../utils/Guardian.sol";
+import { AccountLock } from "../utils/AccountLock.sol";
+import { AccountGuardian } from "../utils/AccountGuardian.sol";
+
+// Extensions
+import "../../../extension/upgradeable//PermissionsEnumerable.sol";
+import "../../../extension/upgradeable//ContractMetadata.sol";
+
+// Interface
+import "../interface/IEntrypoint.sol";
+
+// Smart wallet implementation
+import { GuardianAccount } from "./GuardianAccount.sol";
+
+//   $$\     $$\       $$\                 $$\                         $$\
+//   $$ |    $$ |      \__|                $$ |                        $$ |
+// $$$$$$\   $$$$$$$\  $$\  $$$$$$\   $$$$$$$ |$$\  $$\  $$\  $$$$$$\  $$$$$$$\
+// \_$$  _|  $$  __$$\ $$ |$$  __$$\ $$  __$$ |$$ | $$ | $$ |$$  __$$\ $$  __$$\
+//   $$ |    $$ |  $$ |$$ |$$ |  \__|$$ /  $$ |$$ | $$ | $$ |$$$$$$$$ |$$ |  $$ |
+//   $$ |$$\ $$ |  $$ |$$ |$$ |      $$ |  $$ |$$ | $$ | $$ |$$   ____|$$ |  $$ |
+//   \$$$$  |$$ |  $$ |$$ |$$ |      \$$$$$$$ |\$$$$$\$$$$  |\$$$$$$$\ $$$$$$$  |
+//    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
+
+contract GuardianAccountFactory is BaseAccountFactory, ContractMetadata, PermissionsEnumerable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // states
+    EnumerableSet.AddressSet private allAccounts;
+    address private constant emailService = address(0xa0Ee7A142d267C1f36714E4a8F75612F20a79720); // TODO: To be updated with the wallet address of the actual email service
+    Guardian public guardian;
+    AccountLock public accountLock;
+    AccountGuardian public accountGuardian;
+
+    // Events //
+    event GuardianAccountFactoryContractDeployed(address indexed accountFactory);
+    event GuardianContractDeployed(address indexed guardianContract);
+    event AccountLockContractDeployed(address indexed accountLockContract);
+    event AccountGuardianContractDeployed(address indexed accountGuardianContract);
+
+    /*///////////////////////////////////////////////////////////////
+                            Constructor
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(
+        IEntryPoint _entrypoint
+    ) BaseAccountFactory(address(new GuardianAccount(_entrypoint, address(this))), address(_entrypoint)) {
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        guardian = new Guardian();
+        accountLock = new AccountLock(guardian);
+
+        // emit the contract addresses
+        emit GuardianContractDeployed(address(guardian));
+        emit AccountLockContractDeployed(address(accountLock));
+        emit GuardianAccountFactoryContractDeployed(address(this));
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        External functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Deploys a new Account for admin.
+    function createAccount(address _admin, bytes calldata _email) external virtual override returns (address) {
+        address impl = BaseAccountFactory.accountImplementation;
+        string memory recoveryEmail = abi.decode(_email, (string));
+        bytes32 salt = _generateSalt(_email);
+
+        address account = Clones.predictDeterministicAddress(impl, salt);
+
+        if (account.code.length > 0) {
+            return account;
+        }
+
+        account = Clones.cloneDeterministic(impl, salt);
+
+        if (msg.sender != entrypoint) {
+            require(allAccounts.add(account), "AccountFactory: account already registered");
+        }
+
+        _initializeGuardianAccount(account, _admin, address(guardian), _email);
+        emit AccountCreated(account, _admin);
+
+        accountGuardian = new AccountGuardian(guardian, accountLock, payable(account), emailService, recoveryEmail);
+
+        guardian.linkAccountToAccountGuardian(account, address(accountGuardian));
+
+        emit AccountGuardianContractDeployed(address(accountGuardian));
+
+        return account;
+    }
+
+    /// @notice Callback function for an Account to register itself on the factory.
+    function onRegister(address _defaultAdmin, bytes memory _data) external {
+        address account = msg.sender;
+        require(_isAccountOfFactory(account, _data), "AccountFactory: not an account.");
+
+        require(allAccounts.add(account), "AccountFactory: account already registered");
+    }
+
+    function onSignerAdded(address _signer, address _defaultAdmin, bytes memory _data) external {
+        address account = msg.sender;
+        require(_isAccountOfFactory(account, _data), "AccountFactory: not an account.");
+
+        bool isNewSigner = accountsOfSigner[_signer].add(account);
+
+        if (isNewSigner) {
+            emit SignerAdded(account, _signer);
+        }
+    }
+
+    /// @notice Callback function for an Account to un-register its signers.
+    function onSignerRemoved(address _signer, address _defaultAdmin, bytes memory _data) external {
+        address account = msg.sender;
+        require(_isAccountOfFactory(account, _data), "AccountFactory: not an account.");
+
+        bool isAccount = accountsOfSigner[_signer].remove(account);
+
+        if (isAccount) {
+            emit SignerRemoved(account, _signer);
+        }
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Internal functions
+    //////////////////////////////////////////////////////////////*/
+    /// @dev Returns whether the caller is an account deployed by this factory.
+    function _isAccountOfFactory(address _account, bytes memory _data) internal view virtual returns (bool) {
+        bytes32 salt = _generateSalt(_data);
+        address predicted = Clones.predictDeterministicAddress(BaseAccountFactory.accountImplementation, salt);
+        return _account == predicted;
+    }
+
+    /// @dev Called in `createAccount`. Initializes the account contract created in `createAccount`.
+    function _initializeGuardianAccount(
+        address _account,
+        address _admin,
+        address commonGuardian,
+        bytes calldata _data
+    ) internal {
+        GuardianAccount(payable(_account)).initialize(_admin, commonGuardian, address(accountLock), _data);
+    }
+
+    /// @dev Returns whether contract metadata can be set in the given execution context.
+    function _canSetContractURI() internal view virtual override returns (bool) {
+        return hasRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    /// @dev Returns the salt used when deploying an Account.
+    function _generateSalt(bytes memory _data) internal view virtual returns (bytes32) {
+        return keccak256(_data);
+    }
+
+    ///@dev  returns Account lock contract details
+    function getAccountLock() external view returns (address) {
+        return (address(accountLock));
+    }
+
+    function _initializeAccount(address _account, address _admin, bytes calldata _data) internal virtual override {}
+}

--- a/contracts/prebuilts/account/interface/IAccountFactory.sol
+++ b/contracts/prebuilts/account/interface/IAccountFactory.sol
@@ -9,16 +9,8 @@ interface IAccountFactory is IAccountFactoryCore {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Callback function for an Account to register its signers.
-    function onSignerAdded(
-        address signer,
-        address creatorAdmin,
-        bytes memory data
-    ) external;
+    function onSignerAdded(address signer, bytes32 salt) external;
 
     /// @notice Callback function for an Account to un-register its signers.
-    function onSignerRemoved(
-        address signer,
-        address creatorAdmin,
-        bytes memory data
-    ) external;
+    function onSignerRemoved(address signer, bytes32 salt) external;
 }

--- a/contracts/prebuilts/account/managed/ManagedAccountFactory.sol
+++ b/contracts/prebuilts/account/managed/ManagedAccountFactory.sol
@@ -27,6 +27,7 @@ contract ManagedAccountFactory is BaseAccountFactory, ContractMetadata, Permissi
     //////////////////////////////////////////////////////////////*/
 
     constructor(
+        address _defaultAdmin,
         IEntryPoint _entrypoint,
         Extension[] memory _defaultExtensions
     )
@@ -34,10 +35,10 @@ contract ManagedAccountFactory is BaseAccountFactory, ContractMetadata, Permissi
         BaseAccountFactory(payable(address(new ManagedAccount(_entrypoint, address(this)))), address(_entrypoint))
     {
         __BaseRouter_init();
-        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
 
         bytes32 _extensionRole = keccak256("EXTENSION_ROLE");
-        _setupRole(_extensionRole, msg.sender);
+        _setupRole(_extensionRole, _defaultAdmin);
         _setRoleAdmin(_extensionRole, _extensionRole);
     }
 
@@ -46,13 +47,8 @@ contract ManagedAccountFactory is BaseAccountFactory, ContractMetadata, Permissi
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Called in `createAccount`. Initializes the account contract created in `createAccount`.
-    function _initializeAccount(
-        address _account,
-        address _admin,
-        address _commonGuardian,
-        bytes calldata _data
-    ) internal override {
-        ManagedAccount(payable(_account)).initialize(_admin, _commonGuardian, address(accountLock), _data);
+    function _initializeAccount(address _account, address _admin, bytes calldata _data) internal override {
+        ManagedAccount(payable(_account)).initialize(_admin, _data);
     }
 
     /// @dev Returns whether all relevant permission and other checks are met before any upgrade.

--- a/contracts/prebuilts/account/non-upgradeable/AccountFactory.sol
+++ b/contracts/prebuilts/account/non-upgradeable/AccountFactory.sol
@@ -26,24 +26,15 @@ import { Account } from "./Account.sol";
 //    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
 
 contract AccountFactory is BaseAccountFactory, ContractMetadata, PermissionsEnumerable {
-    // Events //
-    event AccountFactoryContractDeployed(address indexed accountFactory);
-
     /*///////////////////////////////////////////////////////////////
                             Constructor
     //////////////////////////////////////////////////////////////*/
 
     constructor(
+        address _defaultAdmin,
         IEntryPoint _entrypoint
     ) BaseAccountFactory(address(new Account(_entrypoint, address(this))), address(_entrypoint)) {
-        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-
-        emit AccountFactoryContractDeployed(address(this));
-    }
-
-    ///@dev  returns Account lock contract details
-    function getAccountLock() external view returns (address) {
-        return (address(accountLock));
+        _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -51,13 +42,8 @@ contract AccountFactory is BaseAccountFactory, ContractMetadata, PermissionsEnum
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Called in `createAccount`. Initializes the account contract created in `createAccount`.
-    function _initializeAccount(
-        address _account,
-        address _admin,
-        address commonGuardian,
-        bytes calldata _data
-    ) internal override {
-        Account(payable(_account)).initialize(_admin, commonGuardian, address(accountLock), _data);
+    function _initializeAccount(address _account, address _admin, bytes calldata _data) internal override {
+        Account(payable(_account)).initialize(_admin, _data);
     }
 
     /// @dev Returns whether contract metadata can be set in the given execution context.

--- a/contracts/prebuilts/account/utils/AccountCoreStorage.sol
+++ b/contracts/prebuilts/account/utils/AccountCoreStorage.sol
@@ -9,7 +9,7 @@ library AccountCoreStorage {
 
     struct Data {
         address entrypointOverride;
-        address firstAdmin;
+        bytes32 creationSalt;
     }
 
     function data() internal pure returns (Data storage acountCoreData) {

--- a/scripts/DeploySmartAccountUtilContracts.s.sol
+++ b/scripts/DeploySmartAccountUtilContracts.s.sol
@@ -5,7 +5,7 @@ import { Script } from "forge-std/Script.sol";
 import { EntryPoint } from "contracts/prebuilts/account/utils/EntryPoint.sol";
 import { HelperConfig } from "./HelperConfig.s.sol";
 import { AccountLock } from "contracts/prebuilts/account/utils/AccountLock.sol";
-import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { GuardianAccountFactory } from "contracts/prebuilts/account/guardian/GuardianAccountFactory.sol";
 import { Account } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
 import { Guardian } from "contracts/prebuilts/account/utils/Guardian.sol";
 import { AccountGuardian } from "contracts/prebuilts/account/utils/AccountGuardian.sol";
@@ -27,27 +27,37 @@ contract DeploySmartAccountUtilContracts is Script {
     }
 
     // This deploy script should only be used for testing purposes as it deploys a smart account as well.
-    function run() external returns (address, AccountFactory, Guardian, AccountLock, AccountGuardian, AccountRecovery) {
-        AccountFactory accountFactory;
+    function run()
+        external
+        returns (address, GuardianAccountFactory, Guardian, AccountLock, AccountGuardian, AccountRecovery)
+    {
+        GuardianAccountFactory guardianAccountFactory;
 
         uint64 currentNonce = vm.getNonce(networkAccount);
         vm.setNonce(networkAccount, currentNonce);
 
         vm.broadcast(networkAccount);
-        accountFactory = new AccountFactory(entryPoint);
+        guardianAccountFactory = new GuardianAccountFactory(entryPoint);
 
         ///@dev accountGuardian is deployed when new smart account is created using the AccountFactory::createAccount(...)
         vm.setNonce(networkAccount, currentNonce + 1);
         vm.prank(networkAccount);
-        smartWalletAccount = accountFactory.createAccount(admin, abi.encode("shiven@gmail.com"));
+        smartWalletAccount = guardianAccountFactory.createAccount(admin, abi.encode("shiven@gmail.com"));
 
-        Guardian guardianContract = accountFactory.guardian();
-        AccountLock accountLock = accountFactory.accountLock();
+        Guardian guardianContract = guardianAccountFactory.guardian();
+        AccountLock accountLock = guardianAccountFactory.accountLock();
 
         AccountGuardian accountGuardian = AccountGuardian(guardianContract.getAccountGuardian(smartWalletAccount));
 
         AccountRecovery accountRecovery = AccountRecovery(guardianContract.getAccountRecovery(smartWalletAccount));
 
-        return (smartWalletAccount, accountFactory, guardianContract, accountLock, accountGuardian, accountRecovery);
+        return (
+            smartWalletAccount,
+            guardianAccountFactory,
+            guardianContract,
+            accountLock,
+            accountGuardian,
+            accountRecovery
+        );
     }
 }

--- a/src/test/benchmark/AccountBenchmark.t.sol
+++ b/src/test/benchmark/AccountBenchmark.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // Test utils
 import "../utils/BaseTest.sol";
+import { TWProxy } from "contracts/infra/TWProxy.sol";
 
 // Account Abstraction setup for smart wallets.
 import { EntryPoint, IEntryPoint } from "contracts/prebuilts/account/utils/Entrypoint.sol";
@@ -12,6 +13,7 @@ import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.s
 import { IAccountPermissions } from "contracts/extension/interface/IAccountPermissions.sol";
 import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
 import { Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @dev This is a dummy contract to test contract interactions with Account.
 contract Number {
@@ -49,7 +51,7 @@ contract AccountBenchmarkTest is BaseTest {
     address private nonSigner;
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0xBB956D56140CA3f3060986586A2631922a4B347E;
+    address private sender = 0x0df2C3523703d165Aa7fA1a552f3F0B56275DfC6;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -178,9 +180,8 @@ contract AccountBenchmarkTest is BaseTest {
 
         // Setup contracts
         entrypoint = new EntryPoint();
-
         // deploy account factory
-        accountFactory = new AccountFactory(IEntryPoint(payable(address(entrypoint))));
+        accountFactory = new AccountFactory(deployer, IEntryPoint(payable(address(entrypoint))));
         // deploy dummy contract
         numberContract = new Number();
     }

--- a/src/test/smart-wallet/Account.t.sol
+++ b/src/test/smart-wallet/Account.t.sol
@@ -12,6 +12,7 @@ import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.s
 import { IAccountPermissions } from "contracts/extension/interface/IAccountPermissions.sol";
 import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
 import { Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @dev This is a dummy contract to test contract interactions with Account.
 contract Number {
@@ -49,7 +50,7 @@ contract SimpleAccountTest is BaseTest {
     address private nonSigner;
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0xBB956D56140CA3f3060986586A2631922a4B347E;
+    address private sender = 0x0df2C3523703d165Aa7fA1a552f3F0B56275DfC6;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -137,6 +138,63 @@ contract SimpleAccountTest is BaseTest {
         ops[0] = op;
     }
 
+    function _setupUserOpWithSender(
+        bytes memory _initCode,
+        bytes memory _callDataForEntrypoint,
+        address _sender
+    ) internal returns (UserOperation[] memory ops) {
+        uint256 nonce = entrypoint.getNonce(_sender, 0);
+
+        // Get user op fields
+        UserOperation memory op = UserOperation({
+            sender: _sender,
+            nonce: nonce,
+            initCode: _initCode,
+            callData: _callDataForEntrypoint,
+            callGasLimit: 500_000,
+            verificationGasLimit: 500_000,
+            preVerificationGas: 500_000,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+
+        // Sign UserOp
+        bytes32 opHash = EntryPoint(entrypoint).getUserOpHash(op);
+        bytes32 msgHash = ECDSA.toEthSignedMessageHash(opHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountAdminPKey, msgHash);
+        bytes memory userOpSignature = abi.encodePacked(r, s, v);
+
+        address recoveredSigner = ECDSA.recover(msgHash, v, r, s);
+        address expectedSigner = vm.addr(accountAdminPKey);
+        assertEq(recoveredSigner, expectedSigner);
+
+        op.signature = userOpSignature;
+
+        // Store UserOp
+        ops = new UserOperation[](1);
+        ops[0] = op;
+    }
+
+    function _setupUserOpExecuteWithSender(
+        bytes memory _initCode,
+        address _target,
+        uint256 _value,
+        bytes memory _callData,
+        address _sender
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "execute(address,uint256,bytes)",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOpWithSender(_initCode, callDataForEntrypoint, _sender);
+    }
+
     function _setupUserOpExecute(
         uint256 _signerPKey,
         bytes memory _initCode,
@@ -171,6 +229,11 @@ contract SimpleAccountTest is BaseTest {
         return _setupUserOp(_signerPKey, _initCode, callDataForEntrypoint);
     }
 
+    /// @dev Returns the salt used when deploying an Account.
+    function _generateSalt(address _admin, bytes memory _data) internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(_admin, _data));
+    }
+
     function setUp() public override {
         super.setUp();
 
@@ -183,9 +246,8 @@ contract SimpleAccountTest is BaseTest {
 
         // Setup contracts
         entrypoint = new EntryPoint();
-
         // deploy account factory
-        accountFactory = new AccountFactory(IEntryPoint(payable(address(entrypoint))));
+        accountFactory = new AccountFactory(deployer, IEntryPoint(payable(address(entrypoint))));
         // deploy dummy contract
         numberContract = new Number();
     }
@@ -231,7 +293,106 @@ contract SimpleAccountTest is BaseTest {
     function test_revert_onRegister_nonFactoryChildContract() public {
         vm.prank(address(0x12345));
         vm.expectRevert("AccountFactory: not an account.");
-        accountFactory.onRegister(accountAdmin, "");
+        accountFactory.onRegister(_generateSalt(accountAdmin, ""));
+    }
+
+    /// @dev Create more than one accounts with the same admin.
+    function test_state_createAccount_viaEntrypoint_multipleAccountSameAdmin() public {
+        uint256 start = 0;
+        uint256 end = 0;
+
+        assertEq(accountFactory.totalAccounts(), 0);
+
+        vm.expectRevert("BaseAccountFactory: invalid indices");
+        address[] memory accs = accountFactory.getAccounts(start, end);
+
+        uint256 amount = 100;
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            bytes memory initCallData = abi.encodeWithSignature(
+                "createAccount(address,bytes)",
+                accountAdmin,
+                bytes(abi.encode(i))
+            );
+            bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+            address expectedSenderAddress = Clones.predictDeterministicAddress(
+                accountFactory.accountImplementation(),
+                _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                address(accountFactory)
+            );
+
+            UserOperation[] memory userOpCreateAccount = _setupUserOpExecuteWithSender(
+                initCode,
+                address(0),
+                0,
+                bytes(abi.encode(i)),
+                expectedSenderAddress
+            );
+
+            vm.expectEmit(true, true, false, true);
+            emit AccountCreated(expectedSenderAddress, accountAdmin);
+            EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+        }
+
+        address[] memory allAccounts = accountFactory.getAllAccounts();
+        assertEq(allAccounts.length, amount);
+        assertEq(accountFactory.totalAccounts(), amount);
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            assertEq(
+                allAccounts[i],
+                Clones.predictDeterministicAddress(
+                    accountFactory.accountImplementation(),
+                    _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                    address(accountFactory)
+                )
+            );
+        }
+
+        start = 25;
+        end = 75;
+
+        address[] memory accountsPaginatedOne = accountFactory.getAccounts(start, end);
+
+        for (uint256 i = 0; i < (end - start); i += 1) {
+            assertEq(
+                accountsPaginatedOne[i],
+                Clones.predictDeterministicAddress(
+                    accountFactory.accountImplementation(),
+                    _generateSalt(accountAdmin, bytes(abi.encode(start + i))),
+                    address(accountFactory)
+                )
+            );
+        }
+
+        start = 0;
+        end = amount;
+
+        address[] memory accountsPaginatedTwo = accountFactory.getAccounts(start, end);
+
+        for (uint256 i = 0; i < (end - start); i += 1) {
+            assertEq(
+                accountsPaginatedTwo[i],
+                Clones.predictDeterministicAddress(
+                    accountFactory.accountImplementation(),
+                    _generateSalt(accountAdmin, bytes(abi.encode(start + i))),
+                    address(accountFactory)
+                )
+            );
+        }
+
+        start = 75;
+        end = 25;
+
+        vm.expectRevert("BaseAccountFactory: invalid indices");
+        accs = accountFactory.getAccounts(start, end);
+
+        start = 25;
+        end = amount + 1;
+
+        vm.expectRevert("BaseAccountFactory: invalid indices");
+        accs = accountFactory.getAccounts(start, end);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/test/smart-wallet/AccountVulnPOC.t.sol
+++ b/src/test/smart-wallet/AccountVulnPOC.t.sol
@@ -6,10 +6,12 @@ import "../utils/BaseTest.sol";
 // Account Abstraction setup for smart wallets.
 import { EntryPoint, IEntryPoint } from "contracts/prebuilts/account/utils/Entrypoint.sol";
 import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.sol";
+import { TWProxy } from "contracts/infra/TWProxy.sol";
 
 // Target
 import { IAccountPermissions } from "contracts/extension/interface/IAccountPermissions.sol";
-import { AccountFactory, Account } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { AccountFactory, Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 library GPv2EIP1271 {
     bytes4 internal constant MAGICVALUE = 0x1626ba7e;
@@ -39,7 +41,7 @@ contract Number {
         if (owner.code.length == 0) {
             // Signature verification by ECDSA
         } else {
-            // Signature verfication by EIP1271
+            // Signature verification by EIP1271
             bytes32 digest = keccak256(abi.encode(newNum));
             require(
                 EIP1271Verifier(owner).isValidSignature(digest, signature) == GPv2EIP1271.MAGICVALUE,
@@ -69,7 +71,7 @@ contract SimpleAccountVulnPOCTest is BaseTest {
     address private nonSigner;
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0xBB956D56140CA3f3060986586A2631922a4B347E;
+    address private sender = 0x0df2C3523703d165Aa7fA1a552f3F0B56275DfC6;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -203,9 +205,8 @@ contract SimpleAccountVulnPOCTest is BaseTest {
 
         // Setup contracts
         entrypoint = new EntryPoint();
-
         // deploy account factory
-        accountFactory = new AccountFactory(IEntryPoint(payable(address(entrypoint))));
+        accountFactory = new AccountFactory(deployer, IEntryPoint(payable(address(entrypoint))));
         // deploy dummy contract
         numberContract = new Number();
     }
@@ -235,6 +236,8 @@ contract SimpleAccountVulnPOCTest is BaseTest {
         /*//////////////////////////////////////////////////////////
                                 Setup
         //////////////////////////////////////////////////////////////*/
+        address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
         address[] memory approvedTargets = new address[](1);
         approvedTargets[0] = address(0x123); // allowing accountSigner permissions for some random contract, consider it as 0 address here
 
@@ -252,7 +255,6 @@ contract SimpleAccountVulnPOCTest is BaseTest {
 
         vm.prank(accountAdmin);
         bytes memory sig = _signSignerPermissionRequest(permissionsReq);
-        address account = accountFactory.getAddress(accountAdmin, bytes(""));
         IAccountPermissions(payable(account)).setPermissionsForSigner(permissionsReq, sig);
 
         // As expected, Account Signer is not be able to call setNum on numberContract since it doesnt have numberContract as approved target
@@ -274,14 +276,40 @@ contract SimpleAccountVulnPOCTest is BaseTest {
                                 Attack
         //////////////////////////////////////////////////////////////*/
 
-        //However they can bypass this by using signature verification on number contract instead
+        // However they can bypass this by using signature verification on number contract instead
         vm.prank(accountSigner);
         bytes32 digest = keccak256(abi.encode(42));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountSignerPKey, digest);
+        bytes32 toSign = SimpleAccount(payable(account)).getMessageHash(abi.encode(digest));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountSignerPKey, toSign);
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.expectRevert("Account: caller not approved target.");
         numberContract.setNumBySignature(account, 42, signature);
         assertEq(numberContract.num(), 0);
+
+        // Signer can perform transaction if target is approved.
+        address[] memory newApprovedTargets = new address[](2);
+        newApprovedTargets[0] = address(0x123); // allowing accountSigner permissions for some random contract, consider it as 0 address here
+        newApprovedTargets[1] = address(numberContract);
+
+        IAccountPermissions.SignerPermissionRequest memory updatedPermissionsReq = IAccountPermissions
+            .SignerPermissionRequest(
+                accountSigner,
+                0,
+                newApprovedTargets,
+                1 ether,
+                0,
+                type(uint128).max,
+                0,
+                type(uint128).max,
+                bytes32("another UID")
+            );
+
+        vm.prank(accountAdmin);
+        bytes memory sig2 = _signSignerPermissionRequest(updatedPermissionsReq);
+        IAccountPermissions(payable(account)).setPermissionsForSigner(updatedPermissionsReq, sig2);
+
+        numberContract.setNumBySignature(account, 42, signature);
+        assertEq(numberContract.num(), 42);
     }
 }

--- a/src/test/smart-wallet/DeploySmartAccountUtilContractsTest.t.sol
+++ b/src/test/smart-wallet/DeploySmartAccountUtilContractsTest.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.12;
 
 import { Test } from "forge-std/Test.sol";
-import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { GuardianAccountFactory } from "contracts/prebuilts/account/guardian/GuardianAccountFactory.sol";
 import { Guardian } from "contracts/prebuilts/account/utils/Guardian.sol";
 import { AccountGuardian } from "contracts/prebuilts/account/utils/AccountGuardian.sol";
 import { AccountLock } from "contracts/prebuilts/account/utils/AccountLock.sol";
@@ -13,7 +13,7 @@ import { DeploySmartAccountUtilContracts } from "scripts/DeploySmartAccountUtilC
 contract DeploySmartAccountUtilContractsTest is Test {
     address owner = makeAddr("owner");
     address smartAccount;
-    AccountFactory accountFactory;
+    GuardianAccountFactory guardianAccountFactory;
     Guardian guardianContract;
     AccountLock accountLock;
     AccountGuardian accountGuardian;
@@ -21,21 +21,27 @@ contract DeploySmartAccountUtilContractsTest is Test {
 
     function setUp() external {
         DeploySmartAccountUtilContracts deployer = new DeploySmartAccountUtilContracts();
-        (smartAccount, accountFactory, guardianContract, accountLock, accountGuardian, accountRecovery) = deployer
-            .run();
+        (
+            smartAccount,
+            guardianAccountFactory,
+            guardianContract,
+            accountLock,
+            accountGuardian,
+            accountRecovery
+        ) = deployer.run();
     }
 
     function testIfSmartAccountUtilContractsDeployed() external view {
         assert(
             smartAccount != address(0) &&
-                address(accountFactory) != address(0) &&
+                address(guardianAccountFactory) != address(0) &&
                 address(guardianContract) != address(0) &&
                 address(accountLock) != address(0) &&
                 address(accountGuardian) != address(0) &&
                 address(accountRecovery) != address(0)
         );
 
-        assert(guardianContract == accountFactory.guardian());
-        assert(accountLock == accountFactory.accountLock());
+        assert(guardianContract == guardianAccountFactory.guardian());
+        assert(accountLock == guardianAccountFactory.accountLock());
     }
 }

--- a/src/test/smart-wallet/DynamicAccount.t.sol
+++ b/src/test/smart-wallet/DynamicAccount.t.sol
@@ -15,6 +15,7 @@ import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.s
 // Target
 import { Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
 import { DynamicAccountFactory, DynamicAccount } from "contracts/prebuilts/account/dynamic/DynamicAccountFactory.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @dev This is a dummy contract to test contract interactions with Account.
 contract Number {
@@ -41,7 +42,7 @@ contract NFTRejector {
 
 contract DynamicAccountTest is BaseTest {
     // Target contracts
-    EntryPoint private entrypoint;
+    EntryPoint private constant entrypoint = EntryPoint(payable(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789));
     DynamicAccountFactory private accountFactory;
 
     // Mocks
@@ -60,7 +61,7 @@ contract DynamicAccountTest is BaseTest {
     bytes internal data = bytes("");
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0xbC12AEae5E1b1a80401dd20A6728f7a01a3A6166;
+    address private sender = 0x78b942FBC9126b4Ed8384Bb9dd1420Ea865be91a;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -148,6 +149,63 @@ contract DynamicAccountTest is BaseTest {
         ops[0] = op;
     }
 
+    function _setupUserOpWithSender(
+        bytes memory _initCode,
+        bytes memory _callDataForEntrypoint,
+        address _sender
+    ) internal returns (UserOperation[] memory ops) {
+        uint256 nonce = entrypoint.getNonce(_sender, 0);
+
+        // Get user op fields
+        UserOperation memory op = UserOperation({
+            sender: _sender,
+            nonce: nonce,
+            initCode: _initCode,
+            callData: _callDataForEntrypoint,
+            callGasLimit: 5_000_000,
+            verificationGasLimit: 5_000_000,
+            preVerificationGas: 5_000_000,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+
+        // Sign UserOp
+        bytes32 opHash = EntryPoint(entrypoint).getUserOpHash(op);
+        bytes32 msgHash = ECDSA.toEthSignedMessageHash(opHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountAdminPKey, msgHash);
+        bytes memory userOpSignature = abi.encodePacked(r, s, v);
+
+        address recoveredSigner = ECDSA.recover(msgHash, v, r, s);
+        address expectedSigner = vm.addr(accountAdminPKey);
+        assertEq(recoveredSigner, expectedSigner);
+
+        op.signature = userOpSignature;
+
+        // Store UserOp
+        ops = new UserOperation[](1);
+        ops[0] = op;
+    }
+
+    function _setupUserOpExecuteWithSender(
+        bytes memory _initCode,
+        address _target,
+        uint256 _value,
+        bytes memory _callData,
+        address _sender
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "execute(address,uint256,bytes)",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOpWithSender(_initCode, callDataForEntrypoint, _sender);
+    }
+
     function _setupUserOpExecute(
         uint256 _signerPKey,
         bytes memory _initCode,
@@ -182,6 +240,11 @@ contract DynamicAccountTest is BaseTest {
         return _setupUserOp(_signerPKey, _initCode, callDataForEntrypoint);
     }
 
+    /// @dev Returns the salt used when deploying an Account.
+    function _generateSalt(address _admin, bytes memory _data) internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(_admin, _data));
+    }
+
     function setUp() public override {
         super.setUp();
 
@@ -193,7 +256,8 @@ contract DynamicAccountTest is BaseTest {
         nonSigner = vm.addr(nonSignerPKey);
 
         // Setup contracts
-        entrypoint = new EntryPoint();
+        address _deployedEntrypoint = address(new EntryPoint());
+        vm.etch(address(entrypoint), bytes(_deployedEntrypoint.code));
 
         // Setting up default extension.
         IExtension.Extension memory defaultExtension;
@@ -204,7 +268,7 @@ contract DynamicAccountTest is BaseTest {
             implementation: address(new AccountExtension())
         });
 
-        defaultExtension.functions = new IExtension.ExtensionFunction[](7);
+        defaultExtension.functions = new IExtension.ExtensionFunction[](9);
 
         defaultExtension.functions[0] = IExtension.ExtensionFunction(
             AccountExtension.supportsInterface.selector,
@@ -234,12 +298,20 @@ contract DynamicAccountTest is BaseTest {
             AccountExtension.isValidSignature.selector,
             "isValidSignature(bytes32,bytes)"
         );
+        defaultExtension.functions[7] = IExtension.ExtensionFunction(
+            AccountExtension.addDeposit.selector,
+            "addDeposit()"
+        );
+        defaultExtension.functions[8] = IExtension.ExtensionFunction(
+            AccountExtension.withdrawDepositTo.selector,
+            "withdrawDepositTo(address,uint256)"
+        );
 
         IExtension.Extension[] memory extensions = new IExtension.Extension[](1);
         extensions[0] = defaultExtension;
 
         // deploy account factory
-        accountFactory = new DynamicAccountFactory(IEntryPoint(payable(address(entrypoint))), extensions);
+        accountFactory = new DynamicAccountFactory(deployer, extensions);
         // deploy dummy contract
         numberContract = new Number();
     }
@@ -294,10 +366,7 @@ contract DynamicAccountTest is BaseTest {
         extensions[0] = defaultExtension;
 
         // deploy account factory
-        DynamicAccountFactory factory = new DynamicAccountFactory(
-            IEntryPoint(payable(address(entrypoint))),
-            extensions
-        );
+        DynamicAccountFactory factory = new DynamicAccountFactory(deployer, extensions);
     }
 
     /// @dev Create an account by directly calling the factory.
@@ -337,7 +406,53 @@ contract DynamicAccountTest is BaseTest {
     function test_revert_onRegister_nonFactoryChildContract() public {
         vm.prank(address(0x12345));
         vm.expectRevert("AccountFactory: not an account.");
-        accountFactory.onRegister(accountAdmin, "");
+        accountFactory.onRegister(_generateSalt(accountAdmin, ""));
+    }
+
+    /// @dev Create more than one accounts with the same admin.
+    function test_state_createAccount_viaEntrypoint_multipleAccountSameAdmin() public {
+        uint256 amount = 1;
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            bytes memory initCallData = abi.encodeWithSignature(
+                "createAccount(address,bytes)",
+                accountAdmin,
+                bytes(abi.encode(i))
+            );
+            bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+            address expectedSenderAddress = Clones.predictDeterministicAddress(
+                accountFactory.accountImplementation(),
+                _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                address(accountFactory)
+            );
+
+            UserOperation[] memory userOpCreateAccount = _setupUserOpExecuteWithSender(
+                initCode,
+                address(0),
+                0,
+                bytes(abi.encode(i)),
+                expectedSenderAddress
+            );
+
+            vm.expectEmit(true, true, false, true);
+            emit AccountCreated(expectedSenderAddress, accountAdmin);
+            EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+        }
+
+        address[] memory allAccounts = accountFactory.getAllAccounts();
+        assertEq(allAccounts.length, amount);
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            assertEq(
+                allAccounts[i],
+                Clones.predictDeterministicAddress(
+                    accountFactory.accountImplementation(),
+                    _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                    address(accountFactory)
+                )
+            );
+        }
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/test/smart-wallet/ManagedAccount.t.sol
+++ b/src/test/smart-wallet/ManagedAccount.t.sol
@@ -15,6 +15,7 @@ import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.s
 // Target
 import { Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
 import { ManagedAccountFactory, ManagedAccount } from "contracts/prebuilts/account/managed/ManagedAccountFactory.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @dev This is a dummy contract to test contract interactions with Account.
 contract Number {
@@ -61,7 +62,7 @@ contract ManagedAccountTest is BaseTest {
     address private nonSigner;
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0x56C860085A6A0AEd5137b17a185160865bf6a75A;
+    address private sender = 0xbEA1Fa134A1727187A8f2e7E714B660f3a95478D;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -149,6 +150,63 @@ contract ManagedAccountTest is BaseTest {
         ops[0] = op;
     }
 
+    function _setupUserOpWithSender(
+        bytes memory _initCode,
+        bytes memory _callDataForEntrypoint,
+        address _sender
+    ) internal returns (UserOperation[] memory ops) {
+        uint256 nonce = entrypoint.getNonce(_sender, 0);
+
+        // Get user op fields
+        UserOperation memory op = UserOperation({
+            sender: _sender,
+            nonce: nonce,
+            initCode: _initCode,
+            callData: _callDataForEntrypoint,
+            callGasLimit: 5_000_000,
+            verificationGasLimit: 5_000_000,
+            preVerificationGas: 5_000_000,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+
+        // Sign UserOp
+        bytes32 opHash = EntryPoint(entrypoint).getUserOpHash(op);
+        bytes32 msgHash = ECDSA.toEthSignedMessageHash(opHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountAdminPKey, msgHash);
+        bytes memory userOpSignature = abi.encodePacked(r, s, v);
+
+        address recoveredSigner = ECDSA.recover(msgHash, v, r, s);
+        address expectedSigner = vm.addr(accountAdminPKey);
+        assertEq(recoveredSigner, expectedSigner);
+
+        op.signature = userOpSignature;
+
+        // Store UserOp
+        ops = new UserOperation[](1);
+        ops[0] = op;
+    }
+
+    function _setupUserOpExecuteWithSender(
+        bytes memory _initCode,
+        address _target,
+        uint256 _value,
+        bytes memory _callData,
+        address _sender
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "execute(address,uint256,bytes)",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOpWithSender(_initCode, callDataForEntrypoint, _sender);
+    }
+
     function _setupUserOpExecute(
         uint256 _signerPKey,
         bytes memory _initCode,
@@ -183,6 +241,11 @@ contract ManagedAccountTest is BaseTest {
         return _setupUserOp(_signerPKey, _initCode, callDataForEntrypoint);
     }
 
+    /// @dev Returns the salt used when deploying an Account.
+    function _generateSalt(address _admin, bytes memory _data) internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(_admin, _data));
+    }
+
     function setUp() public override {
         super.setUp();
 
@@ -205,7 +268,7 @@ contract ManagedAccountTest is BaseTest {
             implementation: address(new AccountExtension())
         });
 
-        defaultExtension.functions = new IExtension.ExtensionFunction[](7);
+        defaultExtension.functions = new IExtension.ExtensionFunction[](9);
 
         defaultExtension.functions[0] = IExtension.ExtensionFunction(
             AccountExtension.supportsInterface.selector,
@@ -235,13 +298,25 @@ contract ManagedAccountTest is BaseTest {
             AccountExtension.isValidSignature.selector,
             "isValidSignature(bytes32,bytes)"
         );
+        defaultExtension.functions[7] = IExtension.ExtensionFunction(
+            AccountExtension.addDeposit.selector,
+            "addDeposit()"
+        );
+        defaultExtension.functions[8] = IExtension.ExtensionFunction(
+            AccountExtension.withdrawDepositTo.selector,
+            "withdrawDepositTo(address,uint256)"
+        );
 
         IExtension.Extension[] memory extensions = new IExtension.Extension[](1);
         extensions[0] = defaultExtension;
 
         // deploy account factory
         vm.prank(factoryDeployer);
-        accountFactory = new ManagedAccountFactory(IEntryPoint(payable(address(entrypoint))), extensions);
+        accountFactory = new ManagedAccountFactory(
+            factoryDeployer,
+            IEntryPoint(payable(address(entrypoint))),
+            extensions
+        );
         // deploy dummy contract
         numberContract = new Number();
     }
@@ -294,6 +369,7 @@ contract ManagedAccountTest is BaseTest {
         // deploy account factory
         vm.prank(factoryDeployer);
         ManagedAccountFactory factory = new ManagedAccountFactory(
+            factoryDeployer,
             IEntryPoint(payable(address(entrypoint))),
             extensions
         );
@@ -341,7 +417,53 @@ contract ManagedAccountTest is BaseTest {
     function test_revert_onRegister_nonFactoryChildContract() public {
         vm.prank(address(0x12345));
         vm.expectRevert("AccountFactory: not an account.");
-        accountFactory.onRegister(accountAdmin, "");
+        accountFactory.onRegister(_generateSalt(accountAdmin, ""));
+    }
+
+    /// @dev Create more than one accounts with the same admin.
+    function test_state_createAccount_viaEntrypoint_multipleAccountSameAdmin() public {
+        uint256 amount = 1;
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            bytes memory initCallData = abi.encodeWithSignature(
+                "createAccount(address,bytes)",
+                accountAdmin,
+                bytes(abi.encode(i))
+            );
+            bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+            address expectedSenderAddress = Clones.predictDeterministicAddress(
+                accountFactory.accountImplementation(),
+                _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                address(accountFactory)
+            );
+
+            UserOperation[] memory userOpCreateAccount = _setupUserOpExecuteWithSender(
+                initCode,
+                address(0),
+                0,
+                bytes(abi.encode(i)),
+                expectedSenderAddress
+            );
+
+            vm.expectEmit(true, true, false, true);
+            emit AccountCreated(expectedSenderAddress, accountAdmin);
+            EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+        }
+
+        address[] memory allAccounts = accountFactory.getAllAccounts();
+        assertEq(allAccounts.length, amount);
+
+        for (uint256 i = 0; i < amount; i += 1) {
+            assertEq(
+                allAccounts[i],
+                Clones.predictDeterministicAddress(
+                    accountFactory.accountImplementation(),
+                    _generateSalt(accountAdmin, bytes(abi.encode(i))),
+                    address(accountFactory)
+                )
+            );
+        }
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/test/smart-wallet/account-core/isValidSigner.t.sol
+++ b/src/test/smart-wallet/account-core/isValidSigner.t.sol
@@ -60,7 +60,7 @@ contract MyDynamicAccount is DynamicAccount {
         }
     }
 
-    function _setAdmin(address _account, bool _isAdmin, bytes memory _data) internal virtual override {
+    function _setAdmin(address _account, bool _isAdmin) internal virtual override {
         _accountPermissionsStorage().isAdmin[_account] = _isAdmin;
     }
 
@@ -191,14 +191,14 @@ contract AccountCoreTest_isValidSigner is BaseTest {
         IExtension.Extension[] memory extensions;
 
         // deploy account factory
-        accountFactory = new DynamicAccountFactory(IEntryPoint(payable(address(entrypoint))), extensions);
+        accountFactory = new DynamicAccountFactory(deployer, extensions);
         // deploy dummy contract
         numberContract = new Number();
 
         address accountImpl = address(new MyDynamicAccount(IEntryPoint(payable(address(entrypoint))), extensions));
         address _account = Clones.cloneDeterministic(accountImpl, "salt");
         account = MyDynamicAccount(payable(_account));
-        account.initialize(accountAdmin, address(0), address(0), "");
+        account.initialize(accountAdmin, "");
     }
 
     function test_isValidSigner_whenSignerIsAdmin() public {

--- a/src/test/smart-wallet/account-permissions/setPermissionsForSigner.t.sol
+++ b/src/test/smart-wallet/account-permissions/setPermissionsForSigner.t.sol
@@ -15,6 +15,7 @@ import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.s
 // Target
 import { Account as SimpleAccount } from "contracts/prebuilts/account/non-upgradeable/Account.sol";
 import { DynamicAccountFactory, DynamicAccount } from "contracts/prebuilts/account/dynamic/DynamicAccountFactory.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @dev This is a dummy contract to test contract interactions with Account.
 contract Number {
@@ -49,7 +50,7 @@ contract AccountPermissionsTest_setPermissionsForSigner is BaseTest {
     );
 
     // Target contracts
-    EntryPoint private entrypoint;
+    EntryPoint private constant entrypoint = EntryPoint(payable(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789));
     DynamicAccountFactory private accountFactory;
 
     // Mocks
@@ -68,7 +69,7 @@ contract AccountPermissionsTest_setPermissionsForSigner is BaseTest {
     bytes internal data = bytes("");
 
     // UserOp terminology: `sender` is the smart wallet.
-    address private sender = 0xbC12AEae5E1b1a80401dd20A6728f7a01a3A6166;
+    address private sender = 0x78b942FBC9126b4Ed8384Bb9dd1420Ea865be91a;
     address payable private beneficiary = payable(address(0x45654));
 
     bytes32 private uidCache = bytes32("random uid");
@@ -209,7 +210,8 @@ contract AccountPermissionsTest_setPermissionsForSigner is BaseTest {
         nonSigner = vm.addr(nonSignerPKey);
 
         // Setup contracts
-        entrypoint = new EntryPoint();
+        address _deployedEntrypoint = address(new EntryPoint());
+        vm.etch(address(entrypoint), bytes(_deployedEntrypoint.code));
 
         // Setting up default extension.
         IExtension.Extension memory defaultExtension;
@@ -255,7 +257,7 @@ contract AccountPermissionsTest_setPermissionsForSigner is BaseTest {
         extensions[0] = defaultExtension;
 
         // deploy account factory
-        accountFactory = new DynamicAccountFactory(IEntryPoint(payable(address(entrypoint))), extensions);
+        accountFactory = new DynamicAccountFactory(deployer, extensions);
         // deploy dummy contract
         numberContract = new Number();
     }

--- a/src/test/smart-wallet/utils/AccountGuardian.t.sol
+++ b/src/test/smart-wallet/utils/AccountGuardian.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.12;
 
 import { Test } from "forge-std/Test.sol";
 import { EntryPoint } from "contracts/prebuilts/account/utils/EntryPoint.sol";
-import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { GuardianAccountFactory } from "contracts/prebuilts/account/guardian/GuardianAccountFactory.sol";
 import { Guardian } from "contracts/prebuilts/account/utils/Guardian.sol";
 import { AccountGuardian } from "contracts/prebuilts/account/utils/AccountGuardian.sol";
 import { AccountLock } from "contracts/prebuilts/account/utils/AccountLock.sol";
@@ -12,7 +12,7 @@ import { DeploySmartAccountUtilContracts } from "scripts/DeploySmartAccountUtilC
 
 contract AccountGuardianTest is Test {
     address smartAccount;
-    AccountFactory accountFactory;
+    GuardianAccountFactory guardianAccountFactory;
     AccountGuardian accountGuardian;
     Guardian public guardianContract;
     AccountLock public accountLock;
@@ -23,7 +23,7 @@ contract AccountGuardianTest is Test {
 
     function setUp() public {
         DeploySmartAccountUtilContracts deployer = new DeploySmartAccountUtilContracts();
-        (smartAccount, accountFactory, guardianContract, accountLock, , ) = deployer.run();
+        (smartAccount, guardianAccountFactory, guardianContract, accountLock, , ) = deployer.run();
 
         // retrieving the deployed accountGuardian contract address from the guardianContracts as it maintains a mapping of smartAccount => accountGuardian contracts.
         accountGuardian = AccountGuardian(guardianContract.getAccountGuardian(smartAccount));

--- a/src/test/smart-wallet/utils/AccountLock.t.sol
+++ b/src/test/smart-wallet/utils/AccountLock.t.sol
@@ -11,11 +11,11 @@ import { IAccountLock } from "contracts/prebuilts/account/interface/IAccountLock
 import { AccountGuardian } from "contracts/prebuilts/account/utils/AccountGuardian.sol";
 import { IAccountLock } from "contracts/prebuilts/account/interface/IAccountLock.sol";
 import { Guardian } from "contracts/prebuilts/account/utils/Guardian.sol";
-import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { GuardianAccountFactory } from "contracts/prebuilts/account/guardian/GuardianAccountFactory.sol";
 import { DeploySmartAccountUtilContracts } from "scripts/DeploySmartAccountUtilContracts.s.sol";
 
 contract AccountLockTest is Test {
-    AccountFactory public accountFactory;
+    GuardianAccountFactory public guardianAccountFactory;
     address public account;
     Guardian public guardianContract;
     AccountLock public accountLock;
@@ -36,9 +36,9 @@ contract AccountLockTest is Test {
 
         deployer = new DeploySmartAccountUtilContracts();
 
-        (account, accountFactory, guardianContract, accountLock, , ) = deployer.run();
+        (account, guardianAccountFactory, guardianContract, accountLock, , ) = deployer.run();
 
-        account = accountFactory.createAccount(admin, abi.encode("shiven@gmail.com"));
+        account = guardianAccountFactory.createAccount(admin, abi.encode("shiven@gmail.com"));
         accountGuardian = AccountGuardian(guardianContract.getAccountGuardian(account));
         vm.deal(guardian, GUARDIAN_STARTING_BALANCE);
     }

--- a/src/test/smart-wallet/utils/AccountRecovery.t.sol
+++ b/src/test/smart-wallet/utils/AccountRecovery.t.sol
@@ -177,11 +177,16 @@ contract AccountRecoveryTest is Test {
         accountRecovery.collectGuardianSignaturesOnRecoveryRequest(secondGuard, secondGuardSignature);
 
         // checking if the smart account admin/owner was updated
-        (bool success, bytes memory currentAdminEncoded) = smartWallet.call(
-            abi.encodeWithSignature("getAccountAdmin()")
-        );
+        (bool success, bytes memory allAdminsArray) = smartWallet.call(abi.encodeWithSignature("getAccountAdmin()"));
 
-        address currentAdmin = abi.decode(currentAdminEncoded, (address));
+        address[] memory allAdmins = abi.decode(allAdminsArray, (address[]));
+        address currentAdmin;
+
+        for (uint256 a = 0; a < allAdmins.length; a++) {
+            if (allAdmins[a] == newEmbeddedWallet) {
+                currentAdmin = allAdmins[a];
+            }
+        }
         assertEq(currentAdmin, newEmbeddedWallet);
     }
 }

--- a/src/test/smart-wallet/utils/Guardian.t.sol
+++ b/src/test/smart-wallet/utils/Guardian.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.12;
 
-import { AccountFactory } from "contracts/prebuilts/account/non-upgradeable/AccountFactory.sol";
+import { GuardianAccountFactory } from "contracts/prebuilts/account/guardian/GuardianAccountFactory.sol";
 import { Guardian } from "contracts/prebuilts/account/utils/Guardian.sol";
 import { IGuardian } from "contracts/prebuilts/account/interface/IGuardian.sol";
 import { Test } from "forge-std/Test.sol";
@@ -10,7 +10,7 @@ import { DeploySmartAccountUtilContracts } from "scripts/DeploySmartAccountUtilC
 contract GuardianTest is Test {
     Guardian public guardian;
     address account;
-    AccountFactory factory;
+    GuardianAccountFactory factory;
     DeploySmartAccountUtilContracts deployer;
     address public user = makeAddr("guardianUser");
     uint256 public STARTING_USER_BALANCE = 10 ether;


### PR DESCRIPTION
Restored non-upgradeable `AccountFactory` and `Account` to their original form and created Guardian wallet contracts as extensions to the thirdweb system.